### PR TITLE
Separate schema-building logic into classes (more sensible units)

### DIFF
--- a/lib/GraphQLSchemaField.ts
+++ b/lib/GraphQLSchemaField.ts
@@ -1,0 +1,28 @@
+type MetadataParameter = {
+    name: string;
+    type: string | Function;
+};
+
+export class GraphQLSchemaField {
+    constructor(
+        readonly target: Function,
+        readonly name: string
+    ) { }
+
+    getMetadata<T>(key: string): T {
+        return Reflect.getMetadata(key, this.target.prototype, this.name);
+    }
+
+    get schema() {
+        let schema = this.name;
+        if (typeof(this.target.prototype[this.name]) === "function") {
+            const parameters = this.getMetadata<MetadataParameter[]>("barnacle:parameters");
+            if (parameters.length > 0) {
+                schema += `(${parameters.map(p => `${p.name}: ${p.type}`)})`;
+            }
+        }
+        const type: string | undefined = this.getMetadata("barnacle:type");
+        if (type) schema += ": " + type;
+        return schema;
+    }
+}

--- a/lib/GraphQLSchemaType.ts
+++ b/lib/GraphQLSchemaType.ts
@@ -1,0 +1,21 @@
+import { GraphQLSchemaField } from "./GraphQLSchemaField";
+
+export class GraphQLSchemaType {
+    readonly fields: {[key: string]: GraphQLSchemaField} = {};
+    constructor(
+        readonly target: Function
+    ) {
+        for (const fieldName of this.fieldNames) {
+            this.fields[fieldName] = new GraphQLSchemaField(this.target, fieldName);
+        }
+    }
+
+    get fieldNames(): string[] {
+        return Reflect.getMetadata("barnacle:fieldNames", this.target.prototype) || [];
+    }
+
+    get schema() {
+        const fieldsSchema = Object.values(this.fields).map(f => f.schema).join("\n\t");
+        return `type ${this.target.name} {\n\t${fieldsSchema}\n}`.replace(/[ ]{4}/g, "\t");
+    }
+}

--- a/lib/decorators/field.ts
+++ b/lib/decorators/field.ts
@@ -26,24 +26,16 @@ export const field = (options?: FieldOptions) => <T, K extends keyof T & string>
     options.nullable = options.nullable === undefined ? false : options.nullable;
     options.arguments = options.arguments || {};
     const type = getFullGraphQLType(options.type, options.nullable);
-    let schema = key as string;
     if (isFunction) {
         const paramTypes = ((Reflect.getMetadata("design:paramtypes", target, key) || []) as any[]).map(type =>
-            getFullGraphQLType(type, false)
+            getFullGraphQLType(type, false)!
         );
         const parameters = getFunctionParameters(target[key] as any).map((parameter, i) => ({
             name: parameter,
             type: options!.arguments![parameter] || paramTypes[i]
         }));
-        if (parameters.length > 0) {
-            schema += `(${parameters.map(p => `${p.name}: ${p.type}`)})`;
-        }
         Reflect.defineMetadata("barnacle:parameters", parameters, target, key);
     }
-    if (type !== undefined) {
-        schema += `: ${type}`;
-    }
     Reflect.defineMetadata("barnacle:type", type, target, key);
-    Reflect.defineMetadata("barnacle:schema", schema, target, key);
-    pushMetadataArray(target, "barnacle:propertyNames", key);
+    pushMetadataArray(target, "barnacle:fieldNames", key);
 };

--- a/lib/toSchema.ts
+++ b/lib/toSchema.ts
@@ -1,7 +1,8 @@
-export function toSchema(target: Function) {
-    const propertyNames: string[] = Reflect.getMetadata("barnacle:propertyNames", target.prototype) || [];
-    const graphqlProperties = propertyNames.map(property =>
-        Reflect.getMetadata("barnacle:schema", target.prototype, property)
-    );
-    return `type ${target.name} {\n\t${graphqlProperties.join("\n\t")}\n}`.replace(/[ ]{4}/g, "\t");
+import { GraphQLSchemaType } from "./GraphQLSchemaType";
+
+export function toSchema(targets: Function | Function[]) {
+    if (typeof(targets) === "function") {
+        targets = [targets];
+    }
+    return targets.map(t => new GraphQLSchemaType(t).schema).join("\n");
 }


### PR DESCRIPTION
Schema generation is no longer in the `field` decorator - it's been moved (mostly) into `GraphQLSchemaField.schema`.

This PR also resolves #3.